### PR TITLE
Handle unwinnable piece selection in Quarto

### DIFF
--- a/main.py
+++ b/main.py
@@ -222,10 +222,20 @@ class QuartoGame:
             # If every available piece results in a win for the opponent then current player loses
             # (If currrent player cannot pick a piece without losing then he loses)
             if all(self.creates_win_for_opponent(piece) for piece in self.available_pieces):
-                self.append_log(action_type = 2, piece_selected=selected_piece, outcome=f"{self.other_player.name} won the game cause {self.current_player.name} can't pick a piece without losing!")
-                self.log.append((self.other_player.name, "WIN", selected_piece, position))
+                # The current player cannot choose a piece without immediately losing.
+                # ``selected_piece`` and ``position`` are undefined in this branch, so
+                # log the outcome without referencing them.
+                self.append_log(
+                    action_type=2,
+                    piece_selected=None,
+                    outcome=(
+                        f"{self.other_player.name} won the game cause {self.current_player.name} "
+                        "can't pick a piece without losing!"
+                    ),
+                )
+                self.log.append((self.other_player.name, "WIN", None, None))
                 self.log_board(comment=f"{self.other_player.name} won the game!")
-                
+
                 return self.other_player  # Return the winner
 
 
@@ -567,7 +577,8 @@ def simulate_games(num_games_per_combination):
     with open("quarto_boards.log", "w", encoding="utf-8") as file:
         file.write("\n".join(board_states_log))
 
-    save_consolidated_log
+    # Persist any remaining consolidated log entries to disk.
+    save_consolidated_log()
 
     for key, value in results.items():
         print(f"{key[0].name} vs {key[1].name}: Player 1 wins {value[0]}, Player 2 wins {value[1]}, Ties {value[2]}")

--- a/tests/test_quarto_game.py
+++ b/tests/test_quarto_game.py
@@ -1,0 +1,28 @@
+import os
+import types
+import sys
+
+# Ensure the project root is on sys.path so ``main`` can be imported
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub out openai_player before importing main to avoid external dependencies
+openai_stub = types.ModuleType("openai_player")
+openai_stub.select_AI_piece = lambda game: None
+openai_stub.select_AI_move = lambda game: (0, 0)
+sys.modules["openai_player"] = openai_stub
+
+# Stub pandas since ``main`` imports it but tests don't rely on it
+pandas_stub = types.ModuleType("pandas")
+sys.modules["pandas"] = pandas_stub
+
+import main
+
+
+def test_game_ends_when_no_safe_piece():
+    player1 = main.Player(main.GameplayType.RANDOM, "Player 1")
+    player2 = main.Player(main.GameplayType.RANDOM, "Player 2")
+    game = main.QuartoGame(player1, player2)
+    # Force scenario where any available piece would give a win to the opponent
+    game.creates_win_for_opponent = lambda piece: True
+    result = game.play_game()
+    assert result == player2


### PR DESCRIPTION
## Summary
- Avoid undefined variable crash when all remaining pieces give the opponent a win
- Persist consolidated logs at the end of simulations
- Add regression test ensuring the game ends cleanly when no safe piece exists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68959e29a1988320a98e9dc6c64f4f82